### PR TITLE
Update caching strategy in type-check workflow

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -14,13 +14,13 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-
+            ${{ runner.os }}-npm-cache-
       - run: npm ci
       - run: npm run type-check
 
@@ -32,12 +32,12 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
-      - name: Cache node_modules
+      - name: Cache npm cache
         uses: actions/cache@v4
         with:
-          path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-cache-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-modules-
+            ${{ runner.os }}-npm-cache-
       - run: npm ci
       - run: npm run test


### PR DESCRIPTION
Revise the caching strategy to utilize the npm cache instead of the node_modules directory, improving efficiency in the type-check workflow.